### PR TITLE
Fixed very minor, but meaningful, typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Callbag](https://github.com/callbag/callbag)-based middleware for [Redux](https://github.com/reactjs/redux).
 
-- Tiny (>350b)
+- Tiny (<350b)
 - Zero dependencies
 - Similar API to redux-observable
 - “Unlimited” operators ([callbag ecosystem](https://github.com/callbag/callbag/wiki))


### PR DESCRIPTION
Actual lib is currently [`< 320 bytes`](https://bundlephobia.com/result?p=reduxbag@0.1.0).